### PR TITLE
Refactor/receipt image path

### DIFF
--- a/lib/data/repositories/database_repository.dart
+++ b/lib/data/repositories/database_repository.dart
@@ -57,6 +57,10 @@ class DatabaseRepository {
     return await _databaseService.deleteAllFoldersExceptRoot();
   }
 
+  Future<void> printAllFolders() async {
+    return await _databaseService.printAllFolders();
+  }
+
   Future<bool> folderExists({String? id, String? name}) async {
     return await _databaseService.folderExists(id: id, name: name);
   }

--- a/lib/data/services/database.dart
+++ b/lib/data/services/database.dart
@@ -33,7 +33,6 @@ class DatabaseService {
     final dbPath = await getDatabasesPath();
     // Create the path in the available directory to store our database.
     final path = '$dbPath/receipts.db';
-
     return await openDatabase(
       // creating database found at new path
       path,
@@ -63,7 +62,7 @@ class DatabaseService {
           CREATE TABLE receipts (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,
-            localPath TEXT NOT NULL,
+            fileName TEXT NOT NULL,
             dateCreated INTEGER NOT NULL,
             lastModified INTEGER NOT NULL,
             storageSize INTEGER NOT NULL,
@@ -118,7 +117,7 @@ class DatabaseService {
       return Receipt(
           id: receipts[i]['id'],
           name: receipts[i]['name'],
-          localPath: receipts[i]['localPath'],
+          fileName: receipts[i]['fileName'],
           dateCreated: receipts[i]['dateCreated'],
           lastModified: receipts[i]['lastModified'],
           storageSize: receipts[i]['storageSize'],
@@ -278,8 +277,9 @@ class DatabaseService {
       }
 
       for (var receipt in receipts) {
+        final receiptPath = Receipt.fromMap(receipt).localPath;
         // deleting receipt image in local storage
-        await FileService.deleteFileFromPath(receipt['localPath']);
+        await FileService.deleteFileFromPath(receiptPath);
 
         // deleting receipt record in db
         await db
@@ -428,7 +428,7 @@ class DatabaseService {
       return Receipt(
           id: maps[i]['id'],
           name: maps[i]['name'],
-          localPath: maps[i]['localPath'],
+          fileName: maps[i]['fileName'],
           dateCreated: maps[i]['dateCreated'],
           lastModified: maps[i]['lastModified'],
           storageSize: maps[i]['storageSize'],
@@ -442,11 +442,11 @@ class DatabaseService {
     final List<Map<String, dynamic>> maps = await db.query('receipts');
     print('num of receipts: ${maps.length}');
     print('All receipts in database:');
-    maps.forEach((receiptMap) {
+    for (var receiptMap in maps) {
       final receipt = Receipt(
           id: receiptMap['id'],
           name: receiptMap['name'],
-          localPath: receiptMap['localPath'],
+          fileName: receiptMap['fileName'],
           dateCreated: receiptMap['dateCreated'],
           lastModified: receiptMap['lastModified'],
           storageSize: receiptMap['storageSize'],
@@ -454,13 +454,13 @@ class DatabaseService {
 
       print('id: ${receipt.id.toString()}');
       print('name: ${receipt.name.toString()}');
-      print('localPath: ${receipt.localPath.toString()}');
+      print('fileName: ${receipt.fileName.toString()}');
       print('dateCreated: ${receipt.dateCreated.toString()}');
       print('dateCreated: ${receipt.dateCreated.toString()}');
       print('lastModified: ${receipt.lastModified.toString()}');
       print('storageSize: ${receipt.storageSize.toString()}');
       print('//--------------//');
-    });
+    }
   }
 
   // Method to get Receipt objects by name from the database
@@ -468,7 +468,7 @@ class DatabaseService {
     final db = await database;
     List<Map<String, dynamic>> maps = await db.query('receipts',
         // retrieving the following columns from the database
-        columns: ['id', 'name', 'localPath', 'dateCreated', 'lastModified', 'storageSize', 'parentId'],
+        columns: ['id', 'name', 'fileName', 'dateCreated', 'lastModified', 'storageSize', 'parentId'],
         // '?'s are replaced with the items in the [whereArgs] field
         where: 'name = ?',
         // [name] is the argument of the function
@@ -477,7 +477,7 @@ class DatabaseService {
       return Receipt(
           id: maps[i]['id'],
           name: maps[i]['name'],
-          localPath: maps[i]['localPath'],
+          fileName: maps[i]['fileName'],
           dateCreated: maps[i]['dateCreated'],
           lastModified: maps[i]['lastModified'],
           storageSize: maps[i]['storageSize'],
@@ -507,7 +507,7 @@ class DatabaseService {
       return Receipt(
           id: maps[i]['id'],
           name: maps[i]['name'],
-          localPath: maps[i]['localPath'],
+          fileName: maps[i]['fileName'],
           dateCreated: maps[i]['dateCreated'],
           lastModified: maps[i]['lastModified'],
           storageSize: maps[i]['storageSize'],
@@ -578,7 +578,7 @@ class DatabaseService {
     final List<Map<String, dynamic>> maps = await db
         // query will return receipts that have tags that match any part of the user's search query
         .rawQuery('''
-        SELECT receipts.id, receipts.name, receipts.localPath, receipts.dateCreated, receipts.lastModified, receipts.storageSize, receipts.parentId
+        SELECT receipts.id, receipts.name, receipts.fileName, receipts.dateCreated, receipts.lastModified, receipts.storageSize, receipts.parentId
         FROM receipts
         INNER JOIN tags ON receipts.id = tags.receiptId
         WHERE tags.tag LIKE '%' || ? || '%'
@@ -591,7 +591,7 @@ class DatabaseService {
       return Receipt(
           id: maps[i]['id'],
           name: maps[i]['name'],
-          localPath: maps[i]['localPath'],
+          fileName: maps[i]['fileName'],
           dateCreated: maps[i]['dateCreated'],
           lastModified: maps[i]['lastModified'],
           storageSize: maps[i]['storageSize'],
@@ -609,7 +609,7 @@ class DatabaseService {
         // the '%' is a wildcard that matches any sequence of characters before or after the specifed string
         // the '||' is a operator used to concatenate the '%' and '?' to form the full search pattern
         .rawQuery('''
-        SELECT receipts.id, receipts.name, receipts.localPath, receipts.dateCreated, receipts.lastModified, receipts.storageSize, receipts.parentId
+        SELECT receipts.id, receipts.name, receipts.fileName, receipts.dateCreated, receipts.lastModified, receipts.storageSize, receipts.parentId
         FROM receipts
         INNER JOIN tags ON receipts.id = tags.receiptId
         WHERE tags.tag LIKE '%' || ? || '%'
@@ -621,7 +621,7 @@ class DatabaseService {
       return Receipt(
           id: maps[i]['id'],
           name: maps[i]['name'],
-          localPath: maps[i]['localPath'],
+          fileName: maps[i]['fileName'],
           dateCreated: maps[i]['dateCreated'],
           lastModified: maps[i]['lastModified'],
           storageSize: maps[i]['storageSize'],

--- a/lib/data/services/database.dart
+++ b/lib/data/services/database.dart
@@ -420,6 +420,26 @@ class DatabaseService {
     }
   }
 
+  Future<void> printAllFolders() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query('folders');
+    print('num of folders: ${maps.length}');
+    print('All folders in database:');
+    for (var folderMap in maps) {
+      final folder = Folder(
+          id: folderMap['id'],
+          name: folderMap['name'],
+          lastModified: folderMap['lastModified'],
+          parentId: folderMap['parentId'],);
+
+      print('id: ${folder.id.toString()}');
+      print('name: ${folder.name.toString()}');
+      print('lastModified: ${folder.lastModified.toString()}');
+      print('parentId: ${folder.parentId.toString()}');
+      print('//--------------//');
+    }
+  }
+
   // Method to get all Receipt objects from the database.
   Future<List<Receipt>> getReceipts() async {
     final db = await database;
@@ -456,9 +476,9 @@ class DatabaseService {
       print('name: ${receipt.name.toString()}');
       print('fileName: ${receipt.fileName.toString()}');
       print('dateCreated: ${receipt.dateCreated.toString()}');
-      print('dateCreated: ${receipt.dateCreated.toString()}');
       print('lastModified: ${receipt.lastModified.toString()}');
       print('storageSize: ${receipt.storageSize.toString()}');
+      print('parentId: ${receipt.parentId.toString()}');
       print('//--------------//');
     }
   }

--- a/lib/data/services/document_path_provider.dart
+++ b/lib/data/services/document_path_provider.dart
@@ -1,0 +1,36 @@
+import 'package:path_provider/path_provider.dart';
+
+// This class is a singleton class responsible for managing
+//  the application documents directory path. The purpose of this class is to
+//  encapsulate and centralize the handling of the documents directory path to
+//  ensure that it is consistently accessible throughout the application.
+// This class is required as the application documents directory path changes between
+// app updates so needs to be fetched whenever the app opens so it can be used to construct the
+// Receipt class' localPath member
+class DocumentDirectoryProvider {
+  DocumentDirectoryProvider._privateConstructor();
+
+  static final DocumentDirectoryProvider _instance =
+      DocumentDirectoryProvider._privateConstructor();
+
+  static DocumentDirectoryProvider get instance => _instance;
+
+  // a private field that stores the application documents directory path.
+  String _appDocDirPath = 'uninitialised path';
+
+  // a public getter to access the `_appDocDirPath`.
+  String get appDocDirPath => _appDocDirPath;
+
+  // a method that asynchronously fetches and sets the application documents directory path.
+  Future<void> initialize() async {
+    try {
+      final dir = await getApplicationDocumentsDirectory();
+      _appDocDirPath = dir.path;
+      print('DocumentDirectoryProvider initialised with appDocDirPath: $_appDocDirPath');
+    } on Exception catch (e) {
+      print("Error initializing appDocDirPath: $e");
+      print('appDocDirPath: $appDocDirPath');
+      rethrow;
+    }
+  }
+}

--- a/lib/data/utils/file_helper.dart
+++ b/lib/data/utils/file_helper.dart
@@ -87,11 +87,34 @@ class FileService {
     }
   }
 
+  static String generateFileName(ImageFileType fileType) {
+    String fileName = 'RCPT_';
+    try {
+      // randomInt is >= 1000 and < 10,000.
+      final int randomInt = Random().nextInt(9000) + 1000;
+
+      if (fileType == ImageFileType.png) {
+        fileName = '$fileName$randomInt.png';
+      } else if (fileType == ImageFileType.heic) {
+        fileName = '$fileName$randomInt.heic';
+      }  else if (fileType == ImageFileType.jpg || fileType == ImageFileType.jpeg) {
+        fileName = '$fileName$randomInt.jpg';
+      } else {
+        throw Exception('Utilities.generateFileName(): unexpected file type');
+      }
+
+      return fileName;
+    } catch (e) {
+      print('Error in generateFileName: $e');
+      rethrow;
+    }
+  }
+
   static Future<String> getLocalImagePath(ImageFileType imageFileType) async {
     try {
       Directory imageDirectory = await getApplicationDocumentsDirectory();
       String imageDirectoryPath = imageDirectory.path;
-      final fileName = Utility.generateFileName(imageFileType);
+      final fileName = generateFileName(imageFileType);
       final localImagePath = '$imageDirectoryPath/$fileName';
 
       return localImagePath;

--- a/lib/data/utils/file_helper.dart
+++ b/lib/data/utils/file_helper.dart
@@ -90,8 +90,8 @@ class FileService {
   static String generateFileName(ImageFileType fileType) {
     String fileName = 'RCPT_';
     try {
-      // randomInt is >= 1000 and < 10,000.
-      final int randomInt = Random().nextInt(9000) + 1000;
+      // randomInt is >= 10000 and < 100,000.
+      final int randomInt = Random().nextInt(90000) + 10000;
 
       if (fileType == ImageFileType.png) {
         fileName = '$fileName$randomInt.png';

--- a/lib/data/utils/receipt_helper.dart
+++ b/lib/data/utils/receipt_helper.dart
@@ -47,8 +47,8 @@ class ReceiptService {
     // Creating receipt object to be stored in local db
     Receipt thisReceipt = Receipt(
         id: receiptUid,
-        name: fileName,
-        localPath: path,
+        name: fileName.split('.').first,
+        fileName: fileName,
         dateCreated: currentTime,
         lastModified: currentTime,
         storageSize: compressedfileSize,

--- a/lib/data/utils/utilities.dart
+++ b/lib/data/utils/utilities.dart
@@ -63,29 +63,6 @@ class Utility {
     }
   }
 
-  static String generateFileName(ImageFileType fileType) {
-    String fileName = 'RCPT_';
-    try {
-      // randomInt is >= 1000 and < 10,000.
-      final int randomInt = Random().nextInt(9000) + 1000;
-
-      if (fileType == ImageFileType.png) {
-        fileName = '$fileName$randomInt.png';
-      } else if (fileType == ImageFileType.heic) {
-        fileName = '$fileName$randomInt.heic';
-      }  else if (fileType == ImageFileType.jpg || fileType == ImageFileType.jpeg) {
-        fileName = '$fileName$randomInt.jpg';
-      } else {
-        throw Exception('Utilities.generateFileName(): unexpected file type');
-      }
-
-      return fileName;
-    } catch (e) {
-      print('Error in generateFileName: $e');
-      rethrow;
-    }
-  }
-
   static String generateUid() {
     try {
       String uid = const Uuid().v4().toString();

--- a/lib/logic/cubits/file_system/file_system_cubit.dart
+++ b/lib/logic/cubits/file_system/file_system_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:receiptcamp/data/data_constants.dart';
 import 'package:receiptcamp/data/repositories/database_repository.dart';
 import 'package:receiptcamp/models/folder.dart';
 
@@ -12,7 +13,7 @@ class FileSystemCubit extends Cubit<FileSystemCubitState> {
   // method to display root folder information when the bottom navigation tab switches to file explorer
   initializeFileSystemCubit() async {
     emit(FileSystemCubitInitial());
-    fetchFolderInformation('a1');
+    fetchFolderInformation(rootFolderId);
   }
 
   // method to fetch displayed folder information, which is required for FolderName, BackButton, FolderView, UploadButton

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:receiptcamp/data/repositories/database_repository.dart';
+import 'package:receiptcamp/data/services/document_path_provider.dart';
 import 'package:receiptcamp/logic/blocs/home/home_bloc.dart';
 import 'package:receiptcamp/bloc_observer.dart';
 import 'package:receiptcamp/logic/blocs/search/search_bloc.dart';
@@ -17,6 +18,10 @@ import 'presentation/ui/ui_constants.dart';
 void main() async {
   Bloc.observer = AppBlocObserver();
   WidgetsFlutterBinding.ensureInitialized();
+  // Initializing DocumentDirectoryProvider.instance in `main()` ensures that the documents directory path is
+  // fetched and set as soon as the application starts, making the path
+  // immediately available to any part of the application that requires it.
+  await DocumentDirectoryProvider.instance.initialize();
   await DatabaseRepository.instance.init();
   await SystemChrome.setPreferredOrientations([
     DeviceOrientation.portraitUp,

--- a/lib/models/receipt.dart
+++ b/lib/models/receipt.dart
@@ -1,37 +1,37 @@
 // ignore_for_file: public_member_api_docs, sort_constructors_first
 import 'dart:convert';
+import 'package:receiptcamp/data/services/document_path_provider.dart';
 
 // class to model receipts to be stored in sql db
 class Receipt {
-    final String id;
-    final String name;
-    final String localPath;
-    final int dateCreated;
-    final int lastModified;
-    // this is in bytes
-    final int storageSize;
-    // the id of the folder that holds this receipt
-    final String parentId;
+  final String id;
+  final String name;
+  final String fileName;
+  final int dateCreated;
+  final int lastModified;
+  // this is in bytes
+  final int storageSize;
+  // the id of the folder that holds this receipt
+  final String parentId;
 
-    const Receipt({
-      required this.id,
+  // builds and returns the full path of the receipt's image based on the app's
+  // current application document directory path
+  String get localPath => '${DocumentDirectoryProvider.instance.appDocDirPath}/$fileName';
+
+  Receipt(
+      {required this.id,
       required this.name,
-      required this.localPath,
+      required this.fileName,
       required this.dateCreated,
       required this.lastModified,
       required this.storageSize,
-      required this.parentId
-    });
-
-    
-
-  
+      required this.parentId});
 
   Map<String, dynamic> toMap() {
     return <String, dynamic>{
       'id': id,
       'name': name,
-      'localPath': localPath,
+      'fileName': fileName,
       'dateCreated': dateCreated,
       'lastModified': lastModified,
       'storageSize': storageSize,
@@ -41,14 +41,13 @@ class Receipt {
 
   factory Receipt.fromMap(Map<String, dynamic> map) {
     return Receipt(
-      id: map['id'] as String,
-      name: map['name'] as String,
-      localPath: map['localPath'] as String,
-      dateCreated: map['dateCreated'] as int,
-      lastModified: map['lastModified'] as int,
-      storageSize: map['storageSize'] as int,
-      parentId: map['parentId'] as String
-    );
+        id: map['id'] as String,
+        name: map['name'] as String,
+        fileName: map['fileName'] as String,
+        dateCreated: map['dateCreated'] as int,
+        lastModified: map['lastModified'] as int,
+        storageSize: map['storageSize'] as int,
+        parentId: map['parentId'] as String);
   }
 
   String toJson() => json.encode(toMap());

--- a/lib/presentation/screens/file_explorer.dart
+++ b/lib/presentation/screens/file_explorer.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:receiptcamp/data/data_constants.dart';
 import 'package:receiptcamp/data/utils/utilities.dart';
 import 'package:receiptcamp/logic/cubits/file_system/file_system_cubit.dart';
 import 'package:receiptcamp/logic/cubits/folder_view/folder_view_cubit.dart';

--- a/lib/presentation/screens/file_explorer.dart
+++ b/lib/presentation/screens/file_explorer.dart
@@ -69,7 +69,7 @@ class _FileExplorerState extends State<FileExplorer> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 10),
-                state.folder.id != 'a1'
+                state.folder.id != rootFolderId
                     ? FolderName(
                         name: state.folder.name,
                       )
@@ -81,7 +81,7 @@ class _FileExplorerState extends State<FileExplorer> {
                   indent: 25,
                   endIndent: 25,
                 ),
-                state.folder.id != 'a1'
+                state.folder.id != rootFolderId
                     ? BackButton(
                         previousFolderId: state.folder.parentId,
                         currentFolderId: state.folder.id,
@@ -201,7 +201,7 @@ class _RefreshableFolderViewState extends State<RefreshableFolderView> {
   @override
   void initState() {
     print('RefreshableFolderView instantiated');
-    context.read<FolderViewCubit>().initFolderView('a1');
+    context.read<FolderViewCubit>().initFolderView(rootFolderId);
     super.initState();
   }
 

--- a/lib/presentation/ui/landing/drawer.dart
+++ b/lib/presentation/ui/landing/drawer.dart
@@ -89,6 +89,15 @@ class AppDrawer extends StatelessWidget {
                     DatabaseRepository.instance.printAllTags();
                   },
                 )
+              : Container(),
+          kDebugMode
+              ? ListTile(
+                  leading: const Icon(Icons.print),
+                  title: const Text('Print all folders'),
+                  onTap: () {
+                    DatabaseRepository.instance.printAllFolders();
+                  },
+                )
               : Container()
         ],
       ),

--- a/test/data/services/database_test.dart
+++ b/test/data/services/database_test.dart
@@ -253,7 +253,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -269,7 +269,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testReceiptById',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -288,7 +288,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receipt1Id,
             name: 'receipt1',
-            localPath: 'testPath1',
+            fileName: 'testName1',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -296,7 +296,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receipt2Id,
             name: 'receipt2',
-            localPath: 'testPath2',
+            fileName: 'testName2',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -317,7 +317,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: receiptDateCreated,
             lastModified: receiptDateCreated,
             storageSize: 100,
@@ -327,7 +327,7 @@ void main() {
         final changedReceipt = Receipt(
             id: receiptId,
             name: 'updatedReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: receiptDateCreated,
             lastModified: changedReceiptLastModified,
             storageSize: 100,
@@ -338,7 +338,7 @@ void main() {
         expect(updatedReceipt.id, receiptId);
         expect(updatedReceipt.name, 'updatedReceipt');
         expect(updatedReceipt.dateCreated, receiptDateCreated);
-        expect(updatedReceipt.localPath, 'testPath');
+        expect(updatedReceipt.fileName, 'testName');
         expect(updatedReceipt.lastModified, changedReceiptLastModified);
         expect(updatedReceipt.storageSize, 100);
         expect(updatedReceipt.parentId, rootFolderId);
@@ -349,7 +349,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -375,7 +375,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testMoveReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -392,7 +392,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testRenameReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -417,7 +417,7 @@ void main() {
           final receipt = Receipt(
             id: 'testId$i',
             name: 'testName$i',
-            localPath: 'testPath$i',
+            fileName: 'testName$i',
             dateCreated: i < 8
                 ? Utility.getCurrentTime()
                 : 1000, // set old timestamp for last two receipts
@@ -455,7 +455,7 @@ void main() {
         final receipt = Receipt(
             id: receiptId,
             name: 'testGetByNameReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -481,7 +481,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId,
             name: 'testTagReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: receiptDateCreated,
             lastModified: receiptDateCreated,
             storageSize: 100,
@@ -508,7 +508,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId,
             name: 'testTagReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: receiptDateCreated,
             lastModified: receiptDateCreated,
             storageSize: 100,
@@ -534,7 +534,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId,
             name: 'testTagReceipt',
-            localPath: 'testPath',
+            fileName: 'testName',
             dateCreated: receiptDateCreated,
             lastModified: receiptDateCreated,
             storageSize: 100,
@@ -567,7 +567,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId1,
             name: 'testReceipt1',
-            localPath: 'testPath1',
+            fileName: 'testName1',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -575,7 +575,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId2,
             name: 'testReceipt2',
-            localPath: 'testPath2',
+            fileName: 'testName2',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -602,7 +602,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId1,
             name: 'testReceipt1',
-            localPath: 'testPath1',
+            fileName: 'testName1',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,
@@ -610,7 +610,7 @@ void main() {
         await dbService.insertReceipt(Receipt(
             id: receiptId2,
             name: 'testReceipt2',
-            localPath: 'testPath2',
+            fileName: 'testName2',
             dateCreated: Utility.getCurrentTime(),
             lastModified: Utility.getCurrentTime(),
             storageSize: 100,

--- a/test/data/utils/file_helper_test.dart
+++ b/test/data/utils/file_helper_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:path/path.dart' as p;
+import 'package:path/path.dart' as p hide equals;
 import 'package:receiptcamp/data/data_constants.dart';
 import 'package:receiptcamp/data/services/database.dart';
 import 'package:receiptcamp/data/utils/file_helper.dart';
@@ -149,6 +149,33 @@ void main() {
       }
     });
 
+    test('generateFileName returns a valid file name', () {
+      for (ImageFileType fileType in ImageFileType.values) {
+        String fileName = FileService.generateFileName(fileType);
+        String numsInFileName = fileName.split('_').last.split('.').first;
+        expect(fileName, isNotNull);
+        expect(fileName, isA<String>());
+        // checks that the generated number in the file name is 4 characters long
+        expect(numsInFileName, hasLength(4));
+        // checks that each character in the generated file name is an integer
+        numsInFileName.split('').forEach((element) => expect(int.parse(element), isA<int>() ));
+
+        // Check the file extension based on the fileType
+        switch (fileType) {
+          case ImageFileType.png:
+            expect(fileName, endsWith('.png'));
+            break;
+          case ImageFileType.heic:
+            expect(fileName, endsWith('.heic'));
+            break;
+          case ImageFileType.jpg:
+          case ImageFileType.jpeg:
+            expect(fileName, endsWith('.jpg'));
+            break;
+        }
+      }
+    });
+
     test('getLocalImagePath returns valid local image path', () async {
       // iterate over ImageFileType.values
       for (final imageFileType in ImageFileType.values) {
@@ -279,7 +306,7 @@ void main() {
       final receipt1 = Receipt(
           id: receipt1Id,
           name: 'testReceipt1',
-          localPath: imagePaths[0],
+          fileName: p.basename(imagePaths[0]),
           dateCreated: Utility.getCurrentTime(),
           lastModified: Utility.getCurrentTime(),
           storageSize: 100,
@@ -290,7 +317,7 @@ void main() {
       final receipt2 = Receipt(
           id: receipt2Id,
           name: 'testReceipt2',
-          localPath: imagePaths[1],
+          fileName: p.basename(imagePaths[1]),
           dateCreated: Utility.getCurrentTime(),
           lastModified: Utility.getCurrentTime(),
           storageSize: 100,

--- a/test/data/utils/file_helper_test.dart
+++ b/test/data/utils/file_helper_test.dart
@@ -156,7 +156,7 @@ void main() {
         expect(fileName, isNotNull);
         expect(fileName, isA<String>());
         // checks that the generated number in the file name is 4 characters long
-        expect(numsInFileName, hasLength(4));
+        expect(numsInFileName, hasLength(5));
         // checks that each character in the generated file name is an integer
         numsInFileName.split('').forEach((element) => expect(int.parse(element), isA<int>() ));
 

--- a/test/data/utils/receipt_helper_test.dart
+++ b/test/data/utils/receipt_helper_test.dart
@@ -43,7 +43,7 @@ class MockReceiptService extends Mock {
   }
 }
 
-void main() {
+void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   const imagePaths = [
@@ -98,7 +98,8 @@ void main() {
       for (final imagePath in imagePaths) {
         final receiptFile = File(imagePath);
         final fileName = basename(receiptFile.path);
-        const folderId = rootFolderName;
+        final noExtensionName = fileName.split('.').first;
+        const folderId = rootFolderId;
         final receiptUid = Utility.generateUid();
 
         final path = receiptFile.path;
@@ -110,8 +111,8 @@ void main() {
         // Creating receipt object to be stored in local db
         Receipt receipt = Receipt(
             id: receiptUid,
-            name: fileName,
-            localPath: path,
+            name: noExtensionName,
+            fileName: fileName,
             dateCreated: currentTime,
             lastModified: currentTime,
             storageSize: compressedfileSize,
@@ -121,8 +122,7 @@ void main() {
         expect(receipt, isA<Receipt>());
         expect(receipt, isNotNull);
         expect(receipt.id, receiptUid);
-        expect(receipt.name, fileName);
-        expect(receipt.localPath, receiptFile.path);
+        expect(receipt.name, noExtensionName);
         expect(receipt.parentId, folderId);
       }
     });

--- a/test/data/utils/utilities_test.dart
+++ b/test/data/utils/utilities_test.dart
@@ -49,33 +49,6 @@ void main() {
       expect(sizeString, matches(RegExp(r'^\d+(\.\d{2})? (B|KB|MB|GB)$')));
     });
 
-    test('generateFileName returns a valid file name', () {
-      for (ImageFileType fileType in ImageFileType.values) {
-        String fileName = Utility.generateFileName(fileType);
-        String numsInFileName = fileName.split('_').last.split('.').first;
-        expect(fileName, isNotNull);
-        expect(fileName, isA<String>());
-        // checks that the generated number in the file name is 4 characters long
-        expect(numsInFileName, hasLength(4));
-        // checks that each character in the generated file name is an integer
-        numsInFileName.split('').forEach((element) => expect(int.parse(element), isA<int>() ));
-
-        // Check the file extension based on the fileType
-        switch (fileType) {
-          case ImageFileType.png:
-            expect(fileName, endsWith('.png'));
-            break;
-          case ImageFileType.heic:
-            expect(fileName, endsWith('.heic'));
-            break;
-          case ImageFileType.jpg:
-          case ImageFileType.jpeg:
-            expect(fileName, endsWith('.jpg'));
-            break;
-        }
-      }
-    });
-
     test('generateUid returns a valid uid', () {
       String uid = Utility.generateUid();
       expect(uid, isNotNull);


### PR DESCRIPTION
Issue:
- Path to document directory changes when you update app/rebuild, specifically in the path, the bold part changes: /var/mobile/Containers/Data/Application/CF639A4D-FB03-4715-A95D-7ECC143D74AF/Documents/RCPT_8399.jpg
- This means the receipt.localPath is incorrect when the app is updated/rebuilt, so the image cannot be accessed

Solution:
- Create DocumentDirectoryProvider() path to retrieve path 
- Call DocumentDirectoryProvider() whenever you retrieve localPath of receipt
- Add receipt class localPath getter to dynamically retrieve appDocDirPath and fileName combined
- Replace receipt class member, ‘localPath’ with ‘fileName’
- Pass the file name as ‘name’ & ‘fileName’ when creating receipt object


Issues with solution:
- If two receipts have the same generated file name, and one of them is deleted, then both will be deleted. The likelihood of this happening is initially 1/10,000

Updates: 
- Receipts db schema
- Replaced all direct ‘a1’ references with rootFolderId constant
- Generated file names contain 5 integers
- Receipt name is now file name with stripped extension originally, previously it was the same as the file name
- Added DocumentDirectoryProvider to dynamically provide application documents directory to receipt file path, so image can be retrieved when this path changes during updates
- Moved Utilities.generateFileName -> FileService.GenerateFileName
- added printAllFolder debug button, methods